### PR TITLE
Add most up-to-date general dependency version from npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "ng2-file-upload": "^1.2.1",
     "rxjs": "^5.4.3",
     "tether": "^1.4.0",
-    "waypoints": "^4.0.1",
-    "xynga-general": "^1.1.2"
+    "waypoints": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
     "rxjs": "^5.4.3",
     "tether": "^1.4.0",
     "waypoints": "^4.0.1",
-    "xynga-general": "git://github.com/xynga/general.git#compile-test"
+    "xynga-general": "^1.1.2"
   }
 }

--- a/src/containers.module.ts
+++ b/src/containers.module.ts
@@ -6,7 +6,7 @@ import {InformationPanelComponent} from './information-panel/information-panel.c
 import {WaypointDirective} from './information-panel/directives/waypoints.directive';
 import {TooltipComponent} from './tooltip/tooltip.component';
 import {TooltipTargetDirective} from './tooltip/directives/tooltip-target.directive';
-import {GeneralModule} from 'xynga-general/general/inline';
+import {GeneralModule} from 'xynga-general';
 import {CommonModule} from '@angular/common';
 import {ModalPanelComponent} from './modal-panel/modal-panel.component';
 import {DragAndDropComponent} from './drag-and-drop/drag-and-drop.component';

--- a/src/containers.module.ts
+++ b/src/containers.module.ts
@@ -6,7 +6,6 @@ import {InformationPanelComponent} from './information-panel/information-panel.c
 import {WaypointDirective} from './information-panel/directives/waypoints.directive';
 import {TooltipComponent} from './tooltip/tooltip.component';
 import {TooltipTargetDirective} from './tooltip/directives/tooltip-target.directive';
-import {GeneralModule} from 'xynga-general';
 import {CommonModule} from '@angular/common';
 import {ModalPanelComponent} from './modal-panel/modal-panel.component';
 import {DragAndDropComponent} from './drag-and-drop/drag-and-drop.component';
@@ -33,7 +32,6 @@ import { FileUploadModule } from 'ng2-file-upload';
     imports:[
         CommonModule,
         BrowserAnimationsModule,
-        GeneralModule,
         RouterModule,
         HttpModule,
         FileUploadModule

--- a/src/information-panel/information-panel.html
+++ b/src/information-panel/information-panel.html
@@ -9,7 +9,7 @@
           {{_helpButtonLabel}}
         </span>
       </div>
-      <div>
+      <div class="information-panel__arrow">
         <ng-content select="[open-icon]"></ng-content>
       </div>
     </button>

--- a/src/information-panel/information-panel.scss
+++ b/src/information-panel/information-panel.scss
@@ -77,6 +77,7 @@ $easeOutQuint: cubic-bezier(0.230, 1.000, 0.320, 1.000);
     border-top: none;
     border-bottom: none;
     border-left: none;
+    cursor: pointer;
 
     &:active, &:focus {
       outline: none;

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1870,12 +1870,6 @@
         "source-map": "0.5.7"
       }
     },
-    "cuint": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
-      "dev": true
-    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -11111,16 +11105,21 @@
       "dev": true,
       "requires": {
         "cuint": "0.2.2"
+      },
+      "dependencies": {
+        "cuint": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+          "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs=",
+          "dev": true
+        }
       }
     },
     "xynga-general": {
-      "version": "git://github.com/xynga/general.git#55690ec5f760b8e09968902d9d73690e11a5756c",
-      "integrity": "sha1-vHCBU8w+2qWrb7LmtBTU2j6Jgqs=",
-      "dev": true,
-      "requires": {
-        "angular2-notifications": "0.7.8",
-        "prismjs": "1.9.0"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/xynga-general/-/xynga-general-1.1.2.tgz",
+      "integrity": "sha512-QrVWyWiMPlXbmo3NoVQWBCcN0qJjNnwmQRILDKUMmnPp5hH8C/Ft21D1/Lz7zq4wBh/m25Whso0tzLC2cxQvUw==",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",

--- a/src/package.json
+++ b/src/package.json
@@ -13,17 +13,6 @@
     "type": "git",
     "url": "https://github.com/xynga/containers.git"
   },
-  "peerDependencies": {
-    "@angular/animations": ">=4.4.4",
-    "@angular/core": ">=4.4.4",
-    "@angular/http": ">=4.4.4",
-    "@angular/router": ">=4.4.6",
-    "ng2-file-upload": "^1.2.1",
-    "rxjs": "^5.4.3",
-    "tether": "^1.4.0",
-    "waypoints": "^4.0.1",
-    "xynga-general": "git://github.com/xynga/general.git#compile-test"
-  },
   "devDependencies": {
     "@angular/animations": "^4.4.4",
     "@angular/cli": "^1.4.4",
@@ -46,7 +35,7 @@
     "tether": "^1.4.0",
     "typescript": "^2.4.2",
     "waypoints": "^4.0.1",
-    "xynga-general": "git://github.com/xynga/general.git#compile-test",
+    "xynga-general": "^1.1.2",
     "zone.js": "^0.8.4"
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -35,7 +35,6 @@
     "tether": "^1.4.0",
     "typescript": "^2.4.2",
     "waypoints": "^4.0.1",
-    "xynga-general": "^1.1.2",
     "zone.js": "^0.8.4"
   }
 }

--- a/testing/package-lock.json
+++ b/testing/package-lock.json
@@ -2015,7 +2015,7 @@
     "delegate": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-      "integrity": "sha1-tmtxwxWFIuirV0T3INjKDCr1kWY=",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
       "optional": true
     },
     "delegates": {
@@ -7636,9 +7636,9 @@
       }
     },
     "prismjs": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.9.0.tgz",
-      "integrity": "sha1-+j4tntw8OIfB8fMJXUHx+bQgDw8=",
+      "version": "1.8.3",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.8.3.tgz",
+      "integrity": "sha1-Sj0UC+XyYUqJh8ojMHM6QNitIHs=",
       "requires": {
         "clipboard": "1.7.1"
       }
@@ -9257,7 +9257,7 @@
     "tiny-emitter": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.0.2.tgz",
-      "integrity": "sha1-gtJ0aKylrejl/R5tIrV91D69+3w=",
+      "integrity": "sha512-2NM0auVBGft5tee/OxP4PI3d8WItkDM+fPnaRAVo6xTDI2knbz9eC5ArWGqtGlYqiH3RU5yMpdyTTO7MguC4ow==",
       "optional": true
     },
     "tmp": {
@@ -10414,12 +10414,9 @@
       }
     },
     "xynga-general": {
-      "version": "git://github.com/xynga/general.git#55690ec5f760b8e09968902d9d73690e11a5756c",
-      "integrity": "sha1-gM1uFZ6z7upVM4nYzgZqLrLjjaI=",
-      "requires": {
-        "angular2-notifications": "0.7.8",
-        "prismjs": "1.9.0"
-      }
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/xynga-general/-/xynga-general-1.1.2.tgz",
+      "integrity": "sha512-QrVWyWiMPlXbmo3NoVQWBCcN0qJjNnwmQRILDKUMmnPp5hH8C/Ft21D1/Lz7zq4wBh/m25Whso0tzLC2cxQvUw=="
     },
     "y18n": {
       "version": "3.2.1",

--- a/testing/package.json
+++ b/testing/package.json
@@ -21,12 +21,14 @@
     "@angular/platform-browser": "^5.0.0",
     "@angular/platform-browser-dynamic": "^5.0.0",
     "@angular/router": "^5.0.0",
+    "angular2-notifications": "^0.7.8",
     "core-js": "^2.4.1",
     "ng2-file-upload": "^1.2.1",
+    "prismjs": "^1.8.3",
     "rxjs": "^5.5.2",
     "tether": "^1.4.0",
     "waypoints": "^4.0.1",
-    "xynga-general": "git://github.com/xynga/general.git#compile-test",
+    "xynga-general": "^1.1.2",
     "zone.js": "^0.8.14"
   },
   "devDependencies": {

--- a/testing/src/app/app.component.html
+++ b/testing/src/app/app.component.html
@@ -50,6 +50,8 @@
       </p>
     </div>
     <information-panel title="Title" helpButtonLabel="Help">
+      <icon icon="help" help-icon></icon>
+      <icon icon="chevron-left-green" open-icon></icon>
       <ul>
         <li><a href>Link 1</a></li>
         <li><a href>Link 2</a></li>
@@ -81,7 +83,7 @@
     </button>
 
     <div class="modal-detail">
-      <!--<icon icon="chevron-left-blue"></icon>-->
+      <icon icon="chevron-left-blue"></icon>
       <button (click)="modalDetailOpen = false">Close expanded window</button>
       <h1>Some Detail Content</h1>
     </div>

--- a/testing/src/app/app.module.ts
+++ b/testing/src/app/app.module.ts
@@ -4,7 +4,7 @@ import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
 import { ContainersModule } from 'xynga-containers';
-import { GeneralModule } from 'xynga-general/general/inline';
+import { GeneralModule } from 'xynga-general';
 import { AppRoutingModule } from './app-routing.module';
 
 


### PR DESCRIPTION
Updated the `package.json` files in the `src` directory (for compilation), `testing` directory (for test Angular app), and root (for publishing: peer dependency) for the latest npm version of `xynga-general' (1.1.2).

In doing so, I was able to add back the icons to the tests for `InformationPanelComponent` and `ModalPanelComponent`. I also added back the class name to the `open-icon` (`information-panel__arrow`) so that the icon given for that element would rotate to reflect the "open/close" look. Also, add `cursor: pointer;` to the Info Panel handle so that it would look "clickable".