### PR TITLE
Changed the Z index on the .information-panel css class

### DIFF
--- a/src/information-panel/information-panel.scss
+++ b/src/information-panel/information-panel.scss
@@ -29,7 +29,7 @@ $easeOutQuint: cubic-bezier(0.230, 1.000, 0.320, 1.000);
   width: 60px;
   top: 0;
   right: 0;
-  z-index: 999;
+  z-index: inherit;
   transition: width 0.6s $easeOutQuint, box-shadow 0.4s;
   will-change: width;
   overflow: hidden;


### PR DESCRIPTION
from 999 to inherit to inherit the z index from it's parent element( that scrolls properly and tucks under the sticky header)